### PR TITLE
ci(workflow): 添加预览版发布流程并优化正式版发布

### DIFF
--- a/.github/workflows/CI-Build-Release.yml
+++ b/.github/workflows/CI-Build-Release.yml
@@ -59,11 +59,21 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: mvn -B package -DskipTests
 
-      - name: 发布 Release
+      - name: 发布正式 Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: target/litemotto-*.jar
           tag_name: ${{ github.ref_name }}
-          name:  Release ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true
+
+      - name: 发布预览 Release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/litemotto-*.jar
+          tag_name: main-${{ steps.sha.outputs.SHORT_SHA }}
+          name: Preview Release ${{ steps.sha.outputs.SHORT_SHA }}
+          draft: true
           generate_release_notes: true


### PR DESCRIPTION
在 CI 工作流中新增预览版发布任务，当推送到 main 分支时自动创建草稿版 Release
同时优化正式版发布的名称格式，保持一致性